### PR TITLE
feat(eventemitter): add clear method to EventEmitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ npm install chiisai-event-emitter
 
 ### Subscribe to an Event
 
+Use `EventEmitter.subscribe(eventName, callback)` to subscribe to an event.
+
 ```ts
 import { EventEmitter } from 'chiisai-event-emitter';
 
@@ -37,12 +39,28 @@ eventEmitter.emit('event')
 
 ### Unsubscibe
 
+`EventEmitter.subscribe(eventName, callback)` method returns a function which can be called to unsubscribe the callback from the event.
+
 ```ts
 const unsubscibe = eventEmitter.subscribe('event', () => console.log('event-handler called!'));
 unsubscribe();
 
 eventEmitter.emit('event')
 // (nothing happened)
+```
+
+### Delete an Event
+
+`EventEmitter.clear(eventName)` method removes an event and all callbacks subscibed to this event.
+
+```ts
+eventEmitter.subscribe('event', () => console.log('event-handler called!'));
+eventEmitter.subscribe('event', () => console.log('another event-handler called!'));
+eventEmitter.clear('event')
+
+eventEmitter.emit('event')
+// (nothing happened)
+
 ```
 
 [build-img]:https://github.com/bencelaszlo/chiisai-event-emitter/actions/workflows/release.yml/badge.svg

--- a/src/EventEmitter.ts
+++ b/src/EventEmitter.ts
@@ -42,10 +42,21 @@ export class EventEmitter {
   /**
    * @param {string} eventName
    * @param {Array<any>} args
+   * @returns void
    */
   emit(eventName: string, ...args: Array<any>): void {
     this.subscriptions
       .get(eventName)
       .forEach(({ callback }) => callback(...args));
+  }
+  /**
+   *
+   * @param eventName eventName to be deleted
+   * @returns void
+   */
+  clear(eventName: string): void {
+    this.subscriptions = new Subscriptions(
+      [...this.subscriptions].filter(([key]) => key !== eventName)
+    );
   }
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -82,4 +82,19 @@ describe('eventEmitter', () => {
     expect(testCallbackB).toHaveBeenCalled();
     expect(testCallbackB).toHaveBeenCalledWith(mockEventArgs);
   });
+
+  it('should not call callbacks after an event has been deleted', () => {
+    const testCallbackA = jest.fn();
+    const testCallbackB = jest.fn();
+
+    const eventEmitter = new EventEmitter();
+    eventEmitter.subscribe('test-event', testCallbackA);
+    eventEmitter.subscribe('test-event', testCallbackB);
+
+    eventEmitter.clear('test-event');
+    eventEmitter.emit('test-event');
+
+    expect(testCallbackA).not.toHaveBeenCalled();
+    expect(testCallbackB).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### Description of change

- add `clear` method to `EventEmitter` which enables deleting events and all its subscribed callbacks

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
